### PR TITLE
カフェ注文のバグを修正

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -20,7 +20,7 @@ def take_order(menus)
   end
   print '>'
   order_number = gets.to_i
-  puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
+  puts "#{menus[order_number - 1][:name]}(#{menus[order_number - 1][:price]}円)ですね。"
   order_number
 end
 
@@ -30,5 +30,5 @@ order1 = take_order(DRINKS)
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = DRINKS[order1 - 1][:price].to_i + FOODS[order2 - 1][:price].to_i
 puts "お会計は#{total}円になります。ありがとうございました！"

--- a/cafe.rb
+++ b/cafe.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 DRINKS = [
-  { name: 'コーヒー', price: '300' },
-  { name: 'カフェラテ', price: '400' },
-  { name: 'チャイ', price: '460' },
-  { name: 'エスプレッソ', price: '340' },
-  { name: '緑茶', price: '450' }
+  { name: 'コーヒー', price: 300 },
+  { name: 'カフェラテ', price: 400 },
+  { name: 'チャイ', price: 460 },
+  { name: 'エスプレッソ', price: 340 },
+  { name: '緑茶', price: 450 }
 ].freeze
 
 FOODS = [
-  { name: 'チーズケーキ', price: '470' },
-  { name: 'アップルパイ', price: '520' },
-  { name: 'ホットサンド', price: '410' }
+  { name: 'チーズケーキ', price: 470 },
+  { name: 'アップルパイ', price: 520 },
+  { name: 'ホットサンド', price: 410 }
 ].freeze
 
 def take_order(menus)
@@ -20,15 +20,16 @@ def take_order(menus)
   end
   print '>'
   order_number = gets.to_i
-  puts "#{menus[order_number - 1][:name]}(#{menus[order_number - 1][:price]}円)ですね。"
-  order_number
+  selected_menu = menus[order_number - 1]
+  puts "#{selected_menu[:name]}(#{selected_menu[:price]}円)ですね。"
+  selected_menu
 end
 
 puts 'bugカフェへようこそ！ご注文は？ 番号でどうぞ'
-order1 = take_order(DRINKS)
+drink_order = take_order(DRINKS) 
 
 puts 'フードメニューはいかがですか?'
-order2 = take_order(FOODS)
+food_order = take_order(FOODS)
 
-total = DRINKS[order1 - 1][:price].to_i + FOODS[order2 - 1][:price].to_i
+total = drink_order[:price] + food_order[:price]
 puts "お会計は#{total}円になります。ありがとうございました！"


### PR DESCRIPTION
### 変更内容
* 23行目・33行目：インデックス番号が正しく反映されるよう訂正しました。
* 33行目：DRINKSとFOODSの順序が逆だったため訂正しました。
* 33行目：価格が文字列での表示になっていたため、数値になるよう訂正しました。

#### 背景
実行時に複数のエラーが出たため、上記の点を修正しました。

